### PR TITLE
Switch to argparse for argument parsing

### DIFF
--- a/nwchem2json/scripts/nwchem2json.py
+++ b/nwchem2json/scripts/nwchem2json.py
@@ -27,7 +27,7 @@ def main(argv=None):
     help='Output json file to write')
   args = parser.parse_args(argv)
 
-  if len(args.files > 1 and args.outfile):
+  if len(args.files) > 1 and args.outfile:
     parser.error('may not specify -o when converting multiple files')
 
   for filename in args.files:

--- a/nwchem2json/scripts/nwchem2json.py
+++ b/nwchem2json/scripts/nwchem2json.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # This source file is part of the NWChemOutputToJson project.
-# Copyright (c) 2016, The Regents of the University of California, through 
-# Lawrence Berkeley National Laboratory (subject to receipt of any required 
+# Copyright (c) 2016, The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory (subject to receipt of any required
 # approvals from the U.S. Dept. of Energy).
 # This source code is released under the BSD 3-Clause License, (the "License").
 # Unless required by applicable law or agreed to in writing, software
@@ -11,26 +11,35 @@
 # limitations under the License.
 ##############################################################################
 from __future__ import absolute_import
-import sys
+import argparse
 
 from nwchem2json import nwchemToJson
 
 
 def main(argv=None):
-    if sys.argv[1] == 'noOrbitals':
-      start = 2
-      argument = 'noOrbitals'
-    else:
-      start = 1
-      argument = ''
-    for files in range(start,len(sys.argv)):
-      fileIn = open(sys.argv[files],'r')
-      fileOut = open(sys.argv[files]+'.json','w')
-      print('Converting file ',sys.argv[files])
-      jsonObj = nwchemToJson.nwchemToJson(argument)
-      fileOut.write(jsonObj.convert(fileIn))
-      fileIn.close()
-      fileOut.close()
+  parser = argparse.ArgumentParser()
+  parser.add_argument('files', nargs='*', help='files to parse')
+  parser.add_argument(
+    '--no-orbitals', action='store_false', default=True, dest='orbitals',
+    help='Dont include orbitals in output')
+  parser.add_argument(
+    '-o', type=argparse.FileType('w'), dest='outfile',
+    help='Output json file to write')
+  args = parser.parse_args(argv)
+
+  if len(args.files > 1 and args.outfile):
+    parser.error('may not specify -o when converting multiple files')
+
+  for filename in args.files:
+    with open(filename) as handle:
+      jsonObj = nwchemToJson.nwchemToJson(processOrbitals=args.orbitals)
+      converted_content = jsonObj.convert(handle)
+
+      if args.outfile:
+        args.outfile.write(converted_content)
+      else:
+        with open(filename + '.json', 'w') as outfile:
+          outfile.write(converted_content)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This replaces the explicit argument parsing with usage of the standard argparse library. It also introduces two changes:
1. (breaking) the `noOrbitals` argument now uses standard option prefix (`--no-orbitals`). 
2. Adds support for `-o my_file.json` to specify the file to write the json file. (defaults to the original logic of writing to <input_file>.json if no output file specified)