### PR TITLE
Adding unconverged molecule data to calculationResults

### DIFF
--- a/nwchem2json/nwchemToJson.py
+++ b/nwchem2json/nwchemToJson.py
@@ -495,6 +495,15 @@ class nwchemToJson:
             break
           line=streamIn.readline()
         self.calcRes['molecule'] = self.molecule.molecule
+      elif line.find('Failed to converge')>=0:
+        unconverged_molecule = moleculeObj()
+        line = streamIn.readline()
+        while line:
+          if 'Geometry "' in line:
+            unconverged_molecule.readGeom(line, streamIn)
+            break
+          line = streamIn.readline()
+        self.calcRes['unconvergedMolecule'] = unconverged_molecule.molecule
       elif  line.find('Task  times')>=0:
         self.calcTask['calculationTime'] = self.readTaskTimes(line)
         break


### PR DESCRIPTION
In the case where geometry doesn't converge, it can be helpful to know
the geometry it was at when it failed so that we can choose an
intelligent way to resume from where we left off.

I store parse out the unconverged molecule in
calculationResults['unconvergedMolecule'] instead of 'molecule' to
differentiate whether or not convergence was reached